### PR TITLE
Corregir desborde de las tarjetas en Safari

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -54,6 +54,7 @@ body {
   background: linear-gradient(180deg, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0.02));
   border: 1px solid rgba(255, 255, 255, 0.1);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08), 0 30px 80px rgba(0, 0, 0, 0.45);
+  -webkit-backdrop-filter: blur(18px);
   backdrop-filter: blur(18px);
 }
 .grad {

--- a/src/components/Atmosphere.tsx
+++ b/src/components/Atmosphere.tsx
@@ -1,6 +1,6 @@
 export function Atmosphere() {
   return (
-    <div aria-hidden="true" className="pointer-events-none absolute inset-0 overflow-clip">
+    <div aria-hidden="true" className="pointer-events-none absolute inset-0 overflow-hidden">
       <div className="parallax absolute inset-x-0 -top-[520px] bottom-0">
         <div className="blob" style={{ width: 720, height: 720, left: -160, top: 400, background: "#b45cff", animation: "drift1 16s ease-in-out infinite" }} />
         <div className="blob" style={{ width: 640, height: 640, left: "55%", top: 580, background: "#f5a524", opacity: 0.35, animation: "drift2 20s ease-in-out infinite" }} />

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -4,9 +4,14 @@ import { WhatsAppLink } from "./WhatsAppLink";
 
 export function Contact() {
   return (
-    <section id="contacto" className="reveal relative mt-20 scroll-mt-24 grid grid-cols-1 gap-8 overflow-clip rounded-3xl border border-white/10 bg-ink-2 p-6 sm:p-10 lg:mt-24 lg:grid-cols-12 lg:rounded-[32px] lg:p-16">
-      <div aria-hidden="true" className="pointer-events-none absolute -bottom-[300px] -left-[150px] h-[600px] w-[600px] rounded-full bg-amber opacity-25 blur-[140px]" />
-      <div aria-hidden="true" className="pointer-events-none absolute -right-[100px] -top-[250px] h-[500px] w-[500px] rounded-full bg-violet opacity-25 blur-[140px]" />
+    <section
+      id="contacto"
+      className="reveal relative mt-20 scroll-mt-24 grid grid-cols-1 gap-8 overflow-hidden rounded-3xl border border-white/10 bg-ink-2 p-6 sm:p-10 lg:mt-24 lg:grid-cols-12 lg:rounded-[32px] lg:p-16"
+      style={{
+        backgroundImage:
+          "radial-gradient(620px 620px at 97% -6%, rgba(180,92,255,0.30), rgba(180,92,255,0) 68%), radial-gradient(700px 700px at 2% 106%, rgba(245,165,36,0.28), rgba(245,165,36,0) 68%)",
+      }}
+    >
       <div className="relative flex flex-col gap-6 lg:col-span-5">
         <h2 className="display text-[40px] leading-[0.95] sm:text-5xl lg:text-[64px]">{contact.title}</h2>
         <p className="text-base leading-relaxed text-muted lg:text-[17px]">{contact.text}</p>

--- a/src/components/Pader.tsx
+++ b/src/components/Pader.tsx
@@ -18,8 +18,10 @@ export function Pader() {
           </a>
         }
       />
-      <div className="reveal relative grid grid-cols-1 gap-8 overflow-clip rounded-3xl border border-white/10 bg-ink-3 p-6 sm:p-8 lg:min-h-[680px] lg:grid-cols-12 lg:rounded-[32px] lg:p-14">
-        <div aria-hidden="true" className="pointer-events-none absolute -right-[200px] -top-[250px] h-[700px] w-[700px] rounded-full bg-pader opacity-35 blur-[140px]" />
+      <div
+        className="reveal relative grid grid-cols-1 gap-8 overflow-hidden rounded-3xl border border-white/10 bg-ink-3 p-6 sm:p-8 lg:min-h-[680px] lg:grid-cols-12 lg:rounded-[32px] lg:p-14"
+        style={{ backgroundImage: "radial-gradient(760px 760px at 92% -8%, rgba(255,26,110,0.40), rgba(255,26,110,0) 68%)" }}
+      >
 
         <div className="relative flex flex-col justify-between gap-8 lg:col-span-5">
           <div className="flex flex-col gap-4">


### PR DESCRIPTION
## Problema

En Safari de iPhone, las tarjetas de PADER y de contacto se desbordaban. En Chrome y en Android no.

Son las dos únicas tarjetas con un halo de color borroso adentro, posicionado fuera de sus límites y contenido por el recorte del contenedor. WebKit no recorta un hijo con `filter: blur()` cuando el contenedor tiene esquinas redondeadas, así que el halo se escapaba.

## Solución

- Los halos borrosos pasan a ser degradados radiales pintados en el fondo de cada tarjeta. Se recortan siempre bien y rinden mejor en el teléfono, sin cambiar el aspecto.
- `overflow-clip` pasa a `overflow-hidden`, de soporte más parejo.
- Se agrega el prefijo `-webkit-` a `backdrop-filter` para iOS 17 y anteriores.

## Verificado

- `build`, `lint` y `typecheck` limpios.
- Móvil a 390 px y escritorio a 1440 px: el halo queda dentro de las esquinas redondeadas.
- Confirmado en el iPhone del usuario sobre el preview de esta rama.

🤖 Generated with [Claude Code](https://claude.com/claude-code)